### PR TITLE
feat: add mobile block action controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,17 @@
             <button data-type="5" title="5: 木ブロック" class="block-btn">🟫</button>
             <button id="gridToggle" title="グリッド表示切替" class="grid-btn">グリッド</button>
         </div>
-        <div class="hint">左クリック=設置 / 右クリック=破壊 / 1-5=種類選択 / G=グリッド切替</div>
+        <div class="hint">左クリック=設置 / 右クリック=破壊 / 1-5=種類選択 / G=グリッド切替 / スマホ: ボタン操作</div>
     </div>
 
     <div id="crosshair" class="crosshair">+</div>
     <canvas id="gameCanvas"></canvas>
+
+    <!-- Mobile Controls -->
+    <div id="mobileControls" class="mobile-controls">
+        <button id="placeBtn" class="mobile-btn active">設置</button>
+        <button id="breakBtn" class="mobile-btn">破壊</button>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -53,6 +53,8 @@ const BLOCK_TYPES = {
 // ===== ワールドデータ =====
 const world = {};
 let currentBlockType = 1;
+let currentAction = 'place';
+const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 // 初期地面作成
 for (let x = -10; x <= 10; x++) {
@@ -137,21 +139,22 @@ canvas.addEventListener('pointerdown', (event) => {
     const position = intersection.object.position;
     const face = intersection.face;
     const normal = face.normal.clone();
+    const action = isMobile ? currentAction : (event.button === 0 ? 'place' : (event.button === 2 ? 'break' : null));
 
-    if (event.button === 0) { // 左クリック - ブロック設置
+    if (action === 'place') {
         const newX = Math.round(position.x + normal.x);
         const newY = Math.round(position.y + normal.y);
         const newZ = Math.round(position.z + normal.z);
-        
+
         // 範囲制限
         if (Math.abs(newX) <= 15 && Math.abs(newZ) <= 15 && newY >= 0 && newY <= 20) {
             addBlock(newX, newY, newZ, currentBlockType);
         }
-    } else if (event.button === 2) { // 右クリック - ブロック破壊
+    } else if (action === 'break') {
         const x = Math.round(position.x);
         const y = Math.round(position.y);
         const z = Math.round(position.z);
-        
+
         // 地面（y=0）は破壊不可
         if (y > 0) {
             removeBlock(x, y, z);
@@ -172,6 +175,8 @@ canvas.addEventListener('contextmenu', (event) => {
 const hud = document.getElementById('hud');
 const blockButtons = hud.querySelectorAll('.block-btn');
 const gridToggle = document.getElementById('gridToggle');
+const placeBtn = document.getElementById('placeBtn');
+const breakBtn = document.getElementById('breakBtn');
 
 // ブロック選択
 blockButtons.forEach(button => {
@@ -187,6 +192,23 @@ function updateActiveButton() {
         const type = parseInt(button.dataset.type);
         button.classList.toggle('active', type === currentBlockType);
     });
+}
+
+if (placeBtn && breakBtn) {
+    placeBtn.addEventListener('click', () => {
+        currentAction = 'place';
+        updateActionButtons();
+    });
+    breakBtn.addEventListener('click', () => {
+        currentAction = 'break';
+        updateActionButtons();
+    });
+}
+
+function updateActionButtons() {
+    if (!placeBtn || !breakBtn) return;
+    placeBtn.classList.toggle('active', currentAction === 'place');
+    breakBtn.classList.toggle('active', currentAction === 'break');
 }
 
 // グリッド切替
@@ -225,6 +247,7 @@ function animate() {
 // ===== 初期化 =====
 buildWorld();
 updateActiveButton();
+updateActionButtons();
 animate();
 
 console.log('まいくら風ボクセルビルダーが起動しました！');

--- a/style.css
+++ b/style.css
@@ -98,6 +98,37 @@ body {
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
 }
 
+/* モバイル操作ボタン */
+.mobile-controls {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1000;
+}
+
+.mobile-btn {
+    width: 60px;
+    height: 60px;
+    border: 2px solid #666;
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    font-size: 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mobile-btn.active {
+    background: rgba(0, 255, 0, 0.3);
+    border-color: #0f0;
+    box-shadow: 0 0 15px rgba(0, 255, 0, 0.5);
+}
+
 /* スマホ対応 */
 @media (max-width: 768px) {
     .hud {
@@ -137,6 +168,16 @@ body {
     .crosshair {
         font-size: 20px;
     }
+
+    .mobile-controls {
+        display: flex;
+    }
+
+    .mobile-btn {
+        width: 55px;
+        height: 55px;
+        font-size: 14px;
+    }
 }
 
 @media (max-width: 480px) {
@@ -157,5 +198,11 @@ body {
 
     .hint {
         font-size: 11px;
+    }
+
+    .mobile-btn {
+        width: 45px;
+        height: 45px;
+        font-size: 12px;
     }
 }


### PR DESCRIPTION
## Summary
- add on-screen buttons for placing and breaking blocks on mobile
- style new mobile controls for smaller screens
- handle mobile button actions in game logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c52a9ced883308a7556d379a14118